### PR TITLE
Allow for composing connected components

### DIFF
--- a/ui-global/connected.js
+++ b/ui-global/connected.js
@@ -5,16 +5,23 @@ import { bindActionCreators } from 'redux';
  * Simplifies the connect & bindActionCreators for react components.
  */
 export default (mapStateToProps, actions) => Component => {
-  const mapDispatchToProps = actions ? (
-    (dispatch) => {
+  const mapDispatchToProps = (dispatch, ownProps) => {
+    if (actions) {
       return {
-        actions: bindActionCreators(actions, dispatch)
+        ...ownProps,
+        actions: {
+          ...ownProps.actions,
+          ...bindActionCreators(actions, dispatch)
+        }
       };
     }
-  ) : null;
+    return ownProps;
+  };
 
   return connect(
     mapStateToProps,
     mapDispatchToProps
   )(Component);
 };
+
+export default connected;


### PR DESCRIPTION
- [x] Rework connected HOC to allow composability

_ie_, don't overwrite or nullify `actions` prop from previous/higher connections.