### PR TITLE
Logger sanitizer

### DIFF
--- a/logger-sanitizer/index.js
+++ b/logger-sanitizer/index.js
@@ -12,8 +12,18 @@ const loggerSanitizer = (data) => {
     return data.map(item => loggerSanitizer(item, blacklistedLogKeys));
   }
 
-  // handle non-objects
-  if (!_isPlainObject(data)) return data;
+  // if non-object, redact if contains any blacklisted keys
+  if (!_isPlainObject(data)) {
+    try {
+      blacklistedLogKeys.forEach((key) => {
+        if (data.toLowerCase().includes(key)) data = '[redacted]';
+      });
+      return data; 
+    } catch(err) {
+      // some other type - lets redact to be on safe side
+      return '[redacted]';
+    }
+  }
 
   // handle objects
   return Object.keys(data).reduce((acc, key) => {

--- a/logger-sanitizer/index.js
+++ b/logger-sanitizer/index.js
@@ -7,22 +7,22 @@ const loggerSanitizer = (data) => {
   // define list of keys to sanitize
   const blacklistedLogKeys = ['pass', 'password', 'pw', 'token', 'credit', 'card', 'cc'];
 
+  // handle null/undefined/bool/num
+  if (data === null || typeof data==='undefined' || typeof data==='boolean' || typeof data==='number') return data;
+
   // handle arrays
   if (_isArray(data)) {
     return data.map(item => loggerSanitizer(item, blacklistedLogKeys));
   }
 
   // if non-object, redact if contains any blacklisted keys
-  if (!_isPlainObject(data)) {
-    try {
-      blacklistedLogKeys.forEach((key) => {
-        if (data.toLowerCase().includes(key)) data = '[redacted]';
-      });
-      return data; 
-    } catch(err) {
-      // some other type - lets redact to be on safe side
-      return '[redacted]';
-    }
+  if (typeof(data)==='string') {
+    blacklistedLogKeys.forEach((key) => {
+      if (data.toLowerCase().includes(key)) {
+        data = '[redacted]';
+      }
+    });
+    return data;
   }
 
   // handle objects
@@ -31,11 +31,7 @@ const loggerSanitizer = (data) => {
     if (blacklistedLogKeys.includes(key.toLowerCase())) {
       acc[key] = '[redacted]';
     } else {
-      if (typeof data[key] === 'object' && data[key] !== null) {
-        acc[key] = loggerSanitizer(data[key], blacklistedLogKeys);
-      } else {
-        acc[key] = data[key];
-      }
+      acc[key] = loggerSanitizer(data[key], blacklistedLogKeys);
     }
     /* eslint-enable no-param-reassign */
     return acc;

--- a/logger-sanitizer/index.js
+++ b/logger-sanitizer/index.js
@@ -6,16 +6,13 @@ const loggerSanitizer = (data) => {
 
   // define list of keys to sanitize
   const blacklistedLogKeys = ['pass', 'password', 'pw', 'token', 'credit', 'card', 'cc'];
-
-  // handle null/undefined/bool/num
-  if (data === null || typeof data==='undefined' || typeof data==='boolean' || typeof data==='number') return data;
-
+  
   // handle arrays
   if (_isArray(data)) {
     return data.map(item => loggerSanitizer(item, blacklistedLogKeys));
   }
 
-  // if non-object, redact if contains any blacklisted keys
+  // handle strings
   if (typeof(data)==='string') {
     blacklistedLogKeys.forEach((key) => {
       if (data.toLowerCase().includes(key)) {
@@ -26,16 +23,21 @@ const loggerSanitizer = (data) => {
   }
 
   // handle objects
-  return Object.keys(data).reduce((acc, key) => {
-    /* eslint-disable no-param-reassign */
-    if (blacklistedLogKeys.includes(key.toLowerCase())) {
-      acc[key] = '[redacted]';
-    } else {
-      acc[key] = loggerSanitizer(data[key], blacklistedLogKeys);
-    }
-    /* eslint-enable no-param-reassign */
-    return acc;
-  }, {});
+  if (typeof(data)==='object' && data !== null) {
+    return Object.keys(data).reduce((acc, key) => {
+      /* eslint-disable no-param-reassign */
+      if (blacklistedLogKeys.includes(key.toLowerCase())) {
+        acc[key] = '[redacted]';
+      } else {
+        acc[key] = loggerSanitizer(data[key], blacklistedLogKeys);
+      }
+      /* eslint-enable no-param-reassign */
+      return acc;
+    }, {});
+  }
+
+  // is another type like boolean or number, return as-is
+  return data;
 };
 
 module.exports = {

--- a/logger-sanitizer/index.spec.js
+++ b/logger-sanitizer/index.spec.js
@@ -33,6 +33,13 @@ describe('Logger messages sanitizer redacts blacklisted passwords, tokens and ke
     expect(data.user).toEqual('tester');
     expect(data.happyKey).toEqual('I am a happy key');
   });
+  it('Should redact a string or json value of an object if it contains blacklisted key', () => {
+    const testLog = { 
+      message: '"{"username":"test","password":"12345"}"' 
+    };
+    const data = loggerSanitizer(testLog);
+    expect(data.message).toEqual('[redacted]');
+  });
   it('Should redact a string if it contains a blacklisted key', () => {
     const testLog = 'You will never guess my password! It\'s 1234';
     const data = loggerSanitizer(testLog);
@@ -57,5 +64,18 @@ describe('Logger messages sanitizer redacts blacklisted passwords, tokens and ke
     expect(data[1].password).toEqual('[redacted]');
     expect(data[2][0].pass).toEqual('[redacted]');
     expect(data[2][1]).toEqual('happyValue2');
+  });
+  it('Should not redact a number, undefined, null, or boolean', () => {
+    const testLog = {
+      testNumber: 1234,
+      testUndef: undefined,
+      testNull: null,
+      testBoolean: false
+    };
+    const data = loggerSanitizer(testLog);
+    expect(data.testNumber).toEqual(1234);
+    expect(data.testUndef).toBeUndefined();
+    expect(data.testNull).toBeNull();
+    expect(data.testBoolean).toBeFalsy();
   });
 });

--- a/logger-sanitizer/index.spec.js
+++ b/logger-sanitizer/index.spec.js
@@ -33,7 +33,12 @@ describe('Logger messages sanitizer redacts blacklisted passwords, tokens and ke
     expect(data.user).toEqual('tester');
     expect(data.happyKey).toEqual('I am a happy key');
   });
-  it('Should not redact a string', () => {
+  it('Should redact a string if it contains a blacklisted key', () => {
+    const testLog = 'You will never guess my password! It\'s 1234';
+    const data = loggerSanitizer(testLog);
+    expect(data).toEqual('[redacted]');
+  });
+  it('Should return the string if it doesn\'t contain a blacklisted key', () => {
     const testLog = 'happyString';
     const data = loggerSanitizer(testLog);
     expect(data).toEqual('happyString');


### PR DESCRIPTION
As @Jacfem discovered in the website logger testing, the sanitizer was missing strings which were potentially sensitive. Plus, I discovered that in our object handler, we only recursed if the value of the key was an object, and therefore, string-type values were being missed. All tests passed and should be all fixed. 