### PR TITLE
Fix bug where all Error objects were being redacted

### DIFF
--- a/logger-sanitizer/index.js
+++ b/logger-sanitizer/index.js
@@ -1,32 +1,17 @@
 const _isArray = require('lodash/isArray');
 const _isString = require('lodash/isString');
-const _isObjectLike = require('lodash/isObjectLike');
+const _isPlainObject = require('lodash/isPlainObject');
+const _isFunction = require('lodash/isFunction');
 
 const REDACTED = '[redacted]';
 const BLACKLIST = ['password', 'creditcard'];
 
 // Replaces password info in a logging message with ['redacted']
 const loggerSanitizer = (data) => {
-  
-  // handle arrays
-  if (_isArray(data)) {
-    return data.map(item => loggerSanitizer(item));
-  }
-
-  // handle strings
-  if (_isString(data)) {
-    const stringContainsBlacklistedKeys = BLACKLIST.some(key => data.toLowerCase().indexOf(key) >= 0);
-    return stringContainsBlacklistedKeys ? REDACTED : data;
-  }
 
   // handle objects
-  if (_isObjectLike(data)) {
+  if (_isPlainObject(data)) {
     const objectKeys = Object.keys(data) || [];
-
-    // account for non-plain objects (Map, Set, Date, etc) - for now, redact these edge cases
-    if (objectKeys.length === 0) return REDACTED;
-
-    // account for "normal" objects
     return objectKeys.reduce((acc, key) => {
       /* eslint-disable no-param-reassign */
       if (BLACKLIST.includes(key.toLowerCase())) {
@@ -39,7 +24,18 @@ const loggerSanitizer = (data) => {
     }, {});
   }
 
-  // is another type like boolean or number, return as-is
+   // handle arrays
+   if (_isArray(data)) {
+    return data.map(item => loggerSanitizer(item));
+  }
+
+  // handle strings and various object types 
+  const stringifiedData = data && _isFunction(data.toString) ? data.toString() : data; 
+  if (_isString(stringifiedData)) {
+    const stringContainsBlacklistedKeys = BLACKLIST.some(key => stringifiedData.toLowerCase().indexOf(key) >= 0);
+    return stringContainsBlacklistedKeys ? REDACTED : stringifiedData; 
+  }
+
   return data;
 };
 

--- a/logger-sanitizer/index.js
+++ b/logger-sanitizer/index.js
@@ -30,7 +30,15 @@ const loggerSanitizer = (data) => {
   }
 
   // handle strings and various object types 
-  const stringifiedData = data && _isFunction(data.toString) ? data.toString() : data; 
+  const dataAsJsonString = JSON.stringify(data);
+  let stringifiedData;
+  //if something like a Set which can't be converted to JSON then call toString
+  if (dataAsJsonString === "{}"){ 
+    stringifiedData = data && _isFunction(data.toString) ? data.toString() : data; 
+  }
+  else {
+    stringifiedData = dataAsJsonString
+  }
   if (_isString(stringifiedData)) {
     const stringContainsBlacklistedKeys = BLACKLIST.some(key => stringifiedData.toLowerCase().indexOf(key) >= 0);
     return stringContainsBlacklistedKeys ? REDACTED : stringifiedData; 

--- a/logger-sanitizer/index.spec.js
+++ b/logger-sanitizer/index.spec.js
@@ -30,9 +30,9 @@ describe('Logger messages sanitizer redacts blacklisted passwords, tokens and ke
       credit: 'order1234'
     };
     const data = loggerSanitizer(testLog);
-    expect(data.user).toEqual('tester');
-    expect(data.credit).toEqual('order1234');
-    expect(data.happyKey).toEqual('I am a happy key');
+    expect(data.user).toEqual('"tester"');
+    expect(data.credit).toEqual('"order1234"');
+    expect(data.happyKey).toEqual('"I am a happy key"');
   });
   it('Should redact a string or json value of an object if it contains blacklisted key', () => {
     const testLog = { 
@@ -49,7 +49,7 @@ describe('Logger messages sanitizer redacts blacklisted passwords, tokens and ke
   it('Should return the string if it doesn\'t contain a blacklisted key', () => {
     const testLog = 'happyString';
     const data = loggerSanitizer(testLog);
-    expect(data).toEqual('happyString');
+    expect(data).toEqual('"happyString"');
   });
   it('Should not filter arrays unless the array value is an object', () => {
     const testLog = [
@@ -61,10 +61,10 @@ describe('Logger messages sanitizer redacts blacklisted passwords, tokens and ke
       ]
     ];
     const data = loggerSanitizer(testLog);
-    expect(data[0]).toEqual('happyValue');
+    expect(data[0]).toEqual('"happyValue"');
     expect(data[1].password).toEqual(REDACTED);
     expect(data[2][0].password).toEqual(REDACTED);
-    expect(data[2][1]).toEqual('happyValue2');
+    expect(data[2][1]).toEqual('"happyValue2"');
   });
   it('Should not redact a number, undefined, null, or boolean', () => {
     const testLog = {
@@ -76,8 +76,8 @@ describe('Logger messages sanitizer redacts blacklisted passwords, tokens and ke
     const data = loggerSanitizer(testLog);
     expect(data.testNumber).toEqual('1234');
     expect(data.testUndef).toBeUndefined();
-    expect(data.testNull).toBeNull();
-    expect(data.testBoolean).toBeFalsy();
+    expect(data.testNull).toEqual('null');
+    expect(data.testBoolean).toEqual('false');
   });
   it('Should not redact an Error Object\'s string representation if it does not includes a blacklisted token', () => {
     const testLog = {
@@ -104,8 +104,7 @@ describe('Logger messages sanitizer redacts blacklisted passwords, tokens and ke
     };
     const customObjectInstance = new CustomObject('bar');
     const CustomObjectWithToString = function(str){
-      this.foo = str;
-      this.toString = () => str;
+      this.password = str;
     }
     const customObjectWithToStringInstance = new CustomObjectWithToString('I have a password');
 
@@ -119,8 +118,8 @@ describe('Logger messages sanitizer redacts blacklisted passwords, tokens and ke
     const data = loggerSanitizer(testLog);
     expect(data.a).toEqual('[object Set]');
     expect(data.b).toEqual('[object Map]');
-    expect(data.c).toContain('Sat Jan 01 2000 00:00:00');
-    expect(data.d).toEqual('[object Object]');
+    expect(data.c).toContain('2000-01-01');
+    expect(data.d).toEqual('{"foo":"bar"}');
     expect(data.e).toEqual(REDACTED);
   });
 });

--- a/logger-sanitizer/index.spec.js
+++ b/logger-sanitizer/index.spec.js
@@ -103,17 +103,24 @@ describe('Logger messages sanitizer redacts blacklisted passwords, tokens and ke
       this.foo = str;
     };
     const customObjectInstance = new CustomObject('bar');
+    const CustomObjectWithToString = function(str){
+      this.foo = str;
+      this.toString = () => str;
+    }
+    const customObjectWithToStringInstance = new CustomObjectWithToString('I have a password');
 
     const testLog = {
       a: someSet,
       b: someMap,
       c: someDate,
-      d: customObjectInstance
+      d: customObjectInstance,
+      e: customObjectWithToStringInstance,
     };
     const data = loggerSanitizer(testLog);
     expect(data.a).toEqual('[object Set]');
     expect(data.b).toEqual('[object Map]');
     expect(data.c).toContain('Sat Jan 01 2000 00:00:00');
     expect(data.d).toEqual('[object Object]');
+    expect(data.e).toEqual(REDACTED);
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imperfectproduce/monkey-wrench",
-  "version": "1.2.2",
+  "version": "1.2.3-beta.0",
   "description": "A collection of shared JavaScript for our node microservices, admin tooling, and the website.",
   "main": "index.js",
   "babel": {


### PR DESCRIPTION
https://imperfect.loggly.com/search#terms=tangelo.hasselback.index-product-never-list&from=2020-02-27T19:33:46.515Z&until=2020-02-27T20:33:46.515Z&source_group=

Is a case where javascript error objects were being redacted.  They were being redacted because the code would redact any _object_ that didn't contain keys.  This PR modifies the behavior to only recursively iterate through plain objects and to instead stringify other non-array objects.

