### PR TITLE
include callstacks after sanitizing

### DIFF
--- a/logger-sanitizer/index.js
+++ b/logger-sanitizer/index.js
@@ -2,6 +2,7 @@ const _isArray = require('lodash/isArray');
 const _isString = require('lodash/isString');
 const _isPlainObject = require('lodash/isPlainObject');
 const _isFunction = require('lodash/isFunction');
+const _isError = require('lodash/isError');
 
 const REDACTED = '[redacted]';
 const BLACKLIST = ['password', 'creditcard'];
@@ -27,6 +28,10 @@ const loggerSanitizer = (data) => {
    // handle arrays
    if (_isArray(data)) {
     return data.map(item => loggerSanitizer(item));
+  }
+
+  if (_isError(data) && _isFunction(data.toString) && data.stack){
+    return `${data.toString()} ${data.stack}`;
   }
 
   // handle strings and various object types 

--- a/logger-sanitizer/index.spec.js
+++ b/logger-sanitizer/index.spec.js
@@ -79,19 +79,20 @@ describe('Logger messages sanitizer redacts blacklisted passwords, tokens and ke
     expect(data.testNull).toEqual('null');
     expect(data.testBoolean).toEqual('false');
   });
-  it('Should not redact an Error Object\'s string representation if it does not includes a blacklisted token', () => {
-    const testLog = {
-      foo: new Error('I\'m innocuous and possibly helpful')
-    };
-    const data = loggerSanitizer(testLog);
-    expect(data.foo).toEqual('Error: I\'m innocuous and possibly helpful');
+  it('Should return an Error Object\'s string representation and callstack', () => {
+    const data = loggerSanitizer(new Error('I\'m innocuous and possibly helpful'));
+    expect(data).toContain('Error: I\'m innocuous and possibly helpful');
+    expect(data).toContain('monkey-wrench/logger-sanitizer/index.spec.js:'); // has callstack information
   });
-  it('Should redact an Error Object\'s string representation if it does includes a blacklisted token', () => {
-    const testLog = {
-      foo: new Error('I might have password data')
-    };
-    const data = loggerSanitizer(testLog);
-    expect(data.foo).toEqual(REDACTED);
+  it('Should return a custom Error Object\'s string representation and callstack', () => {
+    class MyCustomError extends Error {
+      constructor(message) {
+        super(message);
+      }
+    }
+    const data = loggerSanitizer(new MyCustomError('I\'m innocuous and possibly helpful'));
+    expect(data).toContain('Error: I\'m innocuous and possibly helpful');
+    expect(data).toContain('monkey-wrench/logger-sanitizer/index.spec.js:'); // has callstack information
   });
   it('Should play nicely with other object types', () => {
     const someSet = new Set();

--- a/logger-sanitizer/index.spec.js
+++ b/logger-sanitizer/index.spec.js
@@ -82,7 +82,7 @@ describe('Logger messages sanitizer redacts blacklisted passwords, tokens and ke
   it('Should return an Error Object\'s string representation and callstack', () => {
     const data = loggerSanitizer(new Error('I\'m innocuous and possibly helpful'));
     expect(data).toContain('Error: I\'m innocuous and possibly helpful');
-    expect(data).toContain('monkey-wrench/logger-sanitizer/index.spec.js:'); // has callstack information
+    expect(data).toContain('logger-sanitizer/index.spec.js:'); // has callstack information
   });
   it('Should return a custom Error Object\'s string representation and callstack', () => {
     class MyCustomError extends Error {
@@ -92,7 +92,7 @@ describe('Logger messages sanitizer redacts blacklisted passwords, tokens and ke
     }
     const data = loggerSanitizer(new MyCustomError('I\'m innocuous and possibly helpful'));
     expect(data).toContain('Error: I\'m innocuous and possibly helpful');
-    expect(data).toContain('monkey-wrench/logger-sanitizer/index.spec.js:'); // has callstack information
+    expect(data).toContain('logger-sanitizer/index.spec.js:'); // has callstack information
   });
   it('Should play nicely with other object types', () => {
     const someSet = new Set();


### PR DESCRIPTION
https://app.asana.com/0/1146700596030657/1164664281040398

- Fixes an issue where the callstack was being omitted after sanitization.
- Don't sanitize an error object.  The only case where we log sensitive information is if we pass sensitive information as the message `new Error("here is the sensitive data ${passwordVar}"); `.  We defintely do not want to sanitize the callstack otherwise it would be redacted when an error is thrown in something like `password.js`;