### PR TITLE
Zen10 Publish to Github Packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,8 +35,8 @@ jobs:
           name: Authenticate with Github Packages
           command: echo "//npm.pkg.github.com/:_authToken=${NPM_TOKEN}" > ~/.npmrc
       - run:
-        name: Local Workspace Authenticate with Github Packages
-        command: echo "\n//npm.pkg.github.com/:_authToken=${NPM_TOKEN}" >> ~/repo/.npmrc
+          name: Local Workspace Authenticate with Github Packages
+          command: echo "\n//npm.pkg.github.com/:_authToken=${NPM_TOKEN}" >> ~/repo/.npmrc
       - run:
           name: Publish package
           command: npm publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,12 +32,6 @@ jobs:
       - attach_workspace:
           at: ~/repo
       - run:
-          name: Authenticate with Github Packages
-          command: echo "//npm.pkg.github.com/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-      - run:
-          name: Local Workspace Authenticate with Github Packages
-          command: echo "\n//npm.pkg.github.com/:_authToken=${NPM_TOKEN}" >> ~/repo/.npmrc
-      - run:
           name: Publish package
           command: npm publish
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,9 @@ jobs:
           name: Authenticate with Github Packages
           command: echo "//npm.pkg.github.com/:_authToken=${NPM_TOKEN}" > ~/.npmrc
       - run:
+        name: Local Workspace Authenticate with Github Packages
+        command: echo "\n//npm.pkg.github.com/:_authToken=${NPM_TOKEN}" >> ~/repo/.npmrc
+      - run:
           name: Publish package
           command: npm publish
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,8 @@ jobs:
       - attach_workspace:
           at: ~/repo
       - run:
-        name: Authenticate with Github Packages
-        command: echo "//npm.pkg.github.com/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+          name: Authenticate with Github Packages
+          command: echo "//npm.pkg.github.com/:_authToken=${NPM_TOKEN}" > ~/.npmrc
       - run:
           name: Publish package
           command: npm publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,8 @@ jobs:
       - setup_remote_docker:
           version: 17.06.1-ce
       - run:
-        name: Authenticate with Github Packages
-        command: echo "//npm.pkg.github.com/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+          name: Authenticate with Github Packages
+          command: echo "//npm.pkg.github.com/:_authToken=${NPM_TOKEN}" > ~/.npmrc
       - run:
           name: Install Dependencies
           command: yarn install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,6 @@ workflows:
             - build
           filters:
             tags:
-              only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)$/
+              only: /^kyletest*/
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ workflows:
       - build
           filters:
             tags:
-                only: /*/
+              only: /*/
       - publish:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,8 +36,8 @@ workflows:
     jobs:
       - build
       - publish:
-        requires:
-          - build
-        filters:
-          tags:
-            only: /^v.*.*.*/
+          requires:
+            - build
+          filters:
+            tags:
+              only: /^v.*.*.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ workflows:
   version: 2
   build-deploy:
     jobs:
-      - build
+      - build:
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,9 @@ jobs:
       - attach_workspace:
           at: ~/repo
       - run:
+          name: Authenticate with Github Packages
+          command: echo "//npm.pkg.github.com/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+      - run:
           name: Publish package
           command: npm publish
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,4 +40,4 @@ workflows:
             - build
           filters:
             tags:
-              only: /^v.*.*.*/
+              only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,9 @@ workflows:
   build-deploy:
     jobs:
       - build
+          filters:
+            tags:
+                only: /*/
       - publish:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,14 @@ jobs:
       - run:
           name: Tests
           command: yarn test
+      - persist_to_workspace:
+          root: ~/repo
+          paths: .
   publish:
     <<: *defaults
     steps:
+      - attach_workspace:
+          at: ~/repo
       - run:
           name: Publish package
           command: npm publish
@@ -41,3 +46,5 @@ workflows:
           filters:
             tags:
               only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)$/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,6 @@ workflows:
             - build
           filters:
             tags:
-              only: /^kyletest.*/
+              only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)$/
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,9 @@ jobs:
       - attach_workspace:
           at: ~/repo
       - run:
+        name: Authenticate with Github Packages
+        command: echo "//npm.pkg.github.com/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+      - run:
           name: Publish package
           command: npm publish
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,18 +14,30 @@ jobs:
       - checkout
       - setup_remote_docker:
           version: 17.06.1-ce
-      # - run:
-      #     name: Clear Yarn Cache (temp)
-      #     command: yarn cache clean
+      - run:
+        name: Authenticate with Github Packages
+        command: echo "//npm.pkg.github.com/:_authToken=${NPM_TOKEN}" > ~/.npmrc
       - run:
           name: Install Dependencies
           command: yarn install
       - run:
           name: Tests
           command: yarn test
+  publish:
+    <<: *defaults
+    steps:
+      - run:
+          name: Publish package
+          command: npm publish
 
 workflows:
   version: 2
   build-deploy:
     jobs:
       - build
+      - publish:
+        requires:
+          - build
+        filters:
+          tags:
+            only: /^v.*.*.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,10 +43,12 @@ workflows:
   build-deploy:
     jobs:
       - build:
+          context: github
           filters:
             tags:
               only: /.*/
       - publish:
+          context: github
           requires:
             - build
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,12 +42,12 @@ workflows:
       - build
           filters:
             tags:
-              only: /*/
+              only: /.*/
       - publish:
           requires:
             - build
           filters:
             tags:
-              only: /^kyletest*/
+              only: /^kyletest.*/
             branches:
               ignore: /.*/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@imperfectproduce:registry=https://npm.pkg.github.com

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # monkey-wrench
 JS :monkey: :wrench:  
+
+## Publishing
+Monkey-wrench is published to Github Packages under the @imperfectproduce scope. Released packages can be viewed [here](https://github.com/imperfectproduce/monkey-wrench/packages).
+### Publishing to the stable release channel
+CircleCI will automatically publish tags matching a semver pattern `/^v([0-9]+)\.([0-9]+)\.([0-9]+)$/`.  Publishing can most easily be accomplished by running:
+- `yarn version`
+- `git push --follow-tags`
+### Publishing to other release channels
+Sometimes it's necessary to publish to other channels.  These publishes must be done manually.  Here is an example of publishing a beta version:
+- `npm login --registry https://npm.pkg.github.com`
+  - _*NOTE* we login using npm becuase yarn does not support authentication necessary for private packages_
+- `yarn version --new-version 1.2.3-beta.0`
+- `git push --follow-tags`
+- `yarn publish --tag beta`

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git+https://github.com/imperfectproduce/monkey-wrench.git"
   },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
   "author": "",
   "license": "ISC",
   "bugs": {


### PR DESCRIPTION
https://docs.google.com/document/d/13YOWlCvVeazCTUyIjrimLfsCeiITj93yL1T6lugpeVg/edit?usp=sharing

https://github.com/imperfectproduce/website/pull/584

- [x] Publishes to Github Packages
- [x] Updated Readme
- [x] Added CI job to auto publish version tags.  In my experience with internal packages publishing can be a bit error prone if people aren't doing it regularly.  It's really easy for the publish to work, but forget to do things like push the git tag.  Creates a little bit of a headache down the line.  

Without the burden of our old internally hosed packages pattern I hope we can break monkey wrench up into more specialized packages. 

