### PR TITLE
[WIP] Implement logger sanitizer as winston rewriter

### DIFF
--- a/logger-sanitizer/winston-rewriter.js
+++ b/logger-sanitizer/winston-rewriter.js
@@ -1,0 +1,62 @@
+// winston-rewriter.js
+//
+// This file exports a function that implements winston's `rewriter` interface,
+// which is used to mutate the meta object passed to a logging statement.
+//
+// Features:
+//
+// - Blacklist sanitization. Any value whose key appears in the `BLACKLIST`
+//   array is redacted.
+// - Decycling. Any circular references are removed.
+// - JSON enrichment. Maps and Sets are serialized in a lossy but identifiable
+//   way. Errors will delegate to the implementation's internal serialization
+//   method if it's available; otherwise, the message and stack will be logged.
+//
+// Usage:
+//
+// const loggerSanitizer = require('<this module>');
+// myWinstonLogger.rewriters.push(loggerSanitizer);
+
+const traverse = require('traverse');
+
+// Blacklist should contain only lowercase words. Sanitizer will case normalize
+// when looking up keys.
+const BLACKLIST = ['password', 'creditcard'];
+const REDACTED = '[redacted]';
+
+function enrichJSON(value) {
+  switch (true) {
+	case typeof value.toJSON === 'function':
+	  return value.toJSON();
+	case value instanceof Set:
+	  return value.toString();
+	case value instanceof Map:
+	  return value.toString();
+	case value instanceof Error:
+	  return {
+		message: value.message,
+		stack: value.stack
+	  };
+	default:
+	  return value;
+  }
+}
+
+module.exports = function logSanitizer(level, message, meta) {
+  const blackListed = term => term && BLACKLIST.includes(term.toLowerCase());
+
+  return traverse(meta).map(function(v) {
+	// Each value in the meta object has exactly one interpretation, as far as
+	// serialization is concerned.
+	switch (true) {
+	  case blackListed(this.key):
+		this.update(REDACTED);
+		break;
+	  case !!this.circular:
+		this.update('[Circular]');
+		break;
+	  default:
+		this.update(enrichJSON(v));
+	}
+  });
+};

--- a/logger-sanitizer/winston-rewriter.js
+++ b/logger-sanitizer/winston-rewriter.js
@@ -5,7 +5,7 @@
 //
 // Features:
 //
-// - Blacklist sanitization. Any value whose key appears in the `BLACKLIST`
+// - Blocklist sanitization. Any value whose key appears in the `BLOCKLIST`
 //   array is redacted.
 // - Decycling. Any circular references are removed.
 // - JSON enrichment. Maps and Sets are serialized in a lossy but identifiable
@@ -19,9 +19,9 @@
 
 const traverse = require('traverse');
 
-// Blacklist should contain only lowercase words. Sanitizer will case normalize
+// Blocklist should contain only lowercase words. Sanitizer will case normalize
 // when looking up keys.
-const BLACKLIST = ['password', 'creditcard'];
+const BLOCKLIST = ['password', 'creditcard'];
 const REDACTED = '[redacted]';
 
 function enrichJSON(value) {
@@ -43,20 +43,20 @@ function enrichJSON(value) {
 }
 
 module.exports = function logSanitizer(level, message, meta) {
-  const blackListed = term => term && BLACKLIST.includes(term.toLowerCase());
+  const blockListed = term => term && BLOCKLIST.includes(term.toLowerCase());
 
   return traverse(meta).map(function(v) {
-	// Each value in the meta object has exactly one interpretation, as far as
-	// serialization is concerned.
-	switch (true) {
-	  case blackListed(this.key):
-		this.update(REDACTED);
-		break;
-	  case !!this.circular:
-		this.update('[Circular]');
-		break;
-	  default:
-		this.update(enrichJSON(v));
-	}
+    // Each value in the meta object has exactly one interpretation, as far as
+    // serialization is concerned.
+    switch (true) {
+      case blockListed(this.key):
+        this.update(REDACTED);
+        break;
+      case !!this.circular:
+        this.update('[Circular]');
+        break;
+      default:
+        this.update(enrichJSON(v));
+    }
   });
 };

--- a/logger-sanitizer/winston-rewriter.spec.js
+++ b/logger-sanitizer/winston-rewriter.spec.js
@@ -2,7 +2,7 @@ const expect = require('expect');
 const winstonRewriter = require('./winston-rewriter');
 
 describe('winston-rewriter logging sanitization/redaction', () => {
-  it('Should redact blacklisted terms case-insensitively', () => {
+  it('Should redact blocklisted terms case-insensitively', () => {
 	const secrets = {
 	  password: { entireObjectWillBe: 'redacted' },
 	  safeword: 'banana',

--- a/logger-sanitizer/winston-rewriter.spec.js
+++ b/logger-sanitizer/winston-rewriter.spec.js
@@ -1,0 +1,66 @@
+const expect = require('expect');
+const winstonRewriter = require('./winston-rewriter');
+
+describe('winston-rewriter logging sanitization/redaction', () => {
+  it('Should redact blacklisted terms case-insensitively', () => {
+	const secrets = {
+	  password: { entireObjectWillBe: 'redacted' },
+	  safeword: 'banana',
+	  deep: {
+		nested: [
+		  { PasSword: 'secret' }
+		]
+	  }
+	};
+
+	const actual = winstonRewriter('level', 'msg', secrets);
+	expect(actual).toEqual({
+	  password: '[redacted]',
+	  safeword: 'banana',
+	  deep: {
+		nested: [
+		  { PasSword: '[redacted]' }
+		]
+	  }
+	});
+  });
+
+  it('Should delegate to custom toJSON behavior', () => {
+	class MyError {
+	  constructor(message, code) {
+		// Fixme(luke): Can't extend an Error class in Babel 6.x.
+		Error.call(this, message);
+		this.code = code;
+		Error.captureStackTrace(this);
+	  }
+
+	  toJSON() {
+		return `Failed with code(${this.code})`;
+	  }
+	}
+
+	const err = new MyError('ignored message', 404);
+	const actual = winstonRewriter('level', 'msg', err);
+	expect(actual).toEqual('Failed with code(404)');
+  });
+
+  it.skip('Should include stack trace for errors', () => {
+	const err = new Error('msg');
+	const actual = winstonRewriter('level', 'msg', err);
+	expect(actual.stack).toEqual(expect.stringContaining('\n'));
+  });
+
+  it('Should accept circular input', () => {
+	const circular = {};
+	circular.self = circular;
+	circular.child = { parent: circular };
+
+	const actual = winstonRewriter('level', 'msg', circular);
+	expect(actual).toEqual({
+	  self: '[Circular]',
+	  child: {
+		parent: '[Circular]'
+	  }
+	});
+  });
+});

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "moment-timezone": "^0.5.16",
     "react": "16.2.0",
     "react-redux": "^5.0.7",
-    "redux": "^3.7.2"
+    "redux": "^3.7.2",
+    "traverse": "^0.6.6"
   },
   "devDependencies": {
     "expect": "^24.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2011,6 +2011,11 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+traverse@^0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
+  integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
+
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"


### PR DESCRIPTION
https://app.asana.com/0/search/1184978514844905/1179155334910058

The existing logger sanitizer implementation has a couple shortcomings:

- It's unable to accept inputs with circular references. This results in a
  recursive call with no base case, and we've seen instances where the logger
  starves the main thread.
- It produces a string. Winston's `meta` argument will be passed to
  `JSON.stringify` prior to flushing the log statement. Since the sanitizer
  returns the result of `JSON.stringify` itself, consumers of the log statements
  will unwrap the metadata as a string. We won't be able to do any search
  indexing on the fields of these objects.
- Requires additional callsite logic. Each object passed to a log statement must
  be passed through the sanitizer explicitly.

This implementation addresses these:

- Use the `traverse` library for walking (possibly) recursive structures. Using
  the traverse API enables us to choose to either (1) decycle the value, (2)
  sanitize the value, or (3) return a serializable value.
- It does not attempt to do any additional serialization.
- It implements winston's `rewriter` interface, which can be plugged in to the
  logger when it is instantiated, rather than requiring logger clients to
  sanitize the input themselves.

TODO
---------
This implementation relies on class extension semantics, which the current
version of Babel cannot handle. Many third-party libraries implement their own
custom error classes, which inherit from the base `Error` class. Until we can
update Babel here, the rewriter will be unable to identify these extended
errors.

The test that is broken by this outdated version of Babel is skipped, so CI
should pass, but no clients should use this implementation until it has been
updated.