### PR TITLE
Adds contextual logging capability to cache wrapper

### DIFF
--- a/caching/withCaching.js
+++ b/caching/withCaching.js
@@ -25,6 +25,9 @@ const tryGetFromCache = ({ cache, key, logger, name }) => {
     });
 };
 
+const isLogger = thing =>
+  thing && ['debug', 'info', 'warn', 'error'].every(fn => typeof thing[fn] === 'function');
+
 /*
 Read-through cache wrapper function to enhance any fn returning a promise
 */
@@ -40,7 +43,12 @@ const cacheWrapper = (fn, cache, logger, params = {}) => {
 
   return (...args) => {
     const start = Date.now();
-    const key = cacheKeySerializer.apply(null, args);
+    const key = cacheKeySerializer.apply(null, args.filter(arg => !isLogger(arg)));
+	const contextualLogger = args.find(isLogger);
+	if (contextualLogger) {
+	  // eslint-disable-next-line
+	  logger = contextualLogger;
+	}
 
     return tryGetFromCache({ cache, key, logger, name })
       .then(cachedValue => {


### PR DESCRIPTION
The memoizing function that is returned by a `cacheWrapper` will now inspect the
arguments passed in by a caller. If any of the arguments appears to be a logger,
it will use that, otherwise it will fall back to the (global) logger passed at
construction time.

Why? This allows us to pass in contextual loggers, i.e., loggers that have some
context baked into them. In particular, we'll add a request id to the contextual
logger passed in with the calling context and be able to correlate cache lookups
with a per-service request context.