### PR TITLE
Conform to @imperfectproduce/node-logger API for logging

### DIFF
--- a/caching/withCaching.js
+++ b/caching/withCaching.js
@@ -52,7 +52,7 @@ const cacheWrapper = (fn, cache, logger, params = {}) => {
       .then(({ result, cacheHit }) => {
         logger.info(
           {
-			message: `Cache ${ cacheHit ? 'hit' : 'miss' }`,
+            message: `Cache ${ cacheHit ? 'hit' : 'miss' }`,
             name,
             key,
             ms: Date.now() - start,

--- a/caching/withCaching.js
+++ b/caching/withCaching.js
@@ -52,9 +52,9 @@ const cacheWrapper = (fn, cache, logger, params = {}) => {
       .then(({ result, cacheHit }) => {
         logger.info(
           {
+			message: `Cache ${ cacheHit ? 'hit' : 'miss' }`,
             name,
             key,
-            cacheHit,
             ms: Date.now() - start,
           },
           ['cache-metrics']


### PR DESCRIPTION
Node-logger requires a `message` property in the object passed to logging
methods.