### PR TITLE
EN-62 Sanitizer handles circular references AND avoid the JSON.stringify step that results in side-effects

### DIFF
--- a/logger-sanitizer/index.spec.js
+++ b/logger-sanitizer/index.spec.js
@@ -30,9 +30,9 @@ describe('Logger messages sanitizer redacts blacklisted passwords, tokens and ke
       credit: 'order1234'
     };
     const data = loggerSanitizer(testLog);
-    expect(data.user).toEqual('"tester"');
-    expect(data.credit).toEqual('"order1234"');
-    expect(data.happyKey).toEqual('"I am a happy key"');
+    expect(data.user).toEqual(testLog.user);
+    expect(data.credit).toEqual(testLog.credit);
+    expect(data.happyKey).toEqual(testLog.happyKey);
   });
   it('Should redact a string or json value of an object if it contains blacklisted key', () => {
     const testLog = { 
@@ -49,7 +49,7 @@ describe('Logger messages sanitizer redacts blacklisted passwords, tokens and ke
   it('Should return the string if it doesn\'t contain a blacklisted key', () => {
     const testLog = 'happyString';
     const data = loggerSanitizer(testLog);
-    expect(data).toEqual('"happyString"');
+    expect(data).toEqual(testLog);
   });
   it('Should not filter arrays unless the array value is an object', () => {
     const testLog = [
@@ -61,10 +61,10 @@ describe('Logger messages sanitizer redacts blacklisted passwords, tokens and ke
       ]
     ];
     const data = loggerSanitizer(testLog);
-    expect(data[0]).toEqual('"happyValue"');
+    expect(data[0]).toEqual(testLog[0]);
     expect(data[1].password).toEqual(REDACTED);
     expect(data[2][0].password).toEqual(REDACTED);
-    expect(data[2][1]).toEqual('"happyValue2"');
+    expect(data[2][1]).toEqual(testLog[2][1]);
   });
   it('Should not redact a number, undefined, null, or boolean', () => {
     const testLog = {
@@ -74,15 +74,15 @@ describe('Logger messages sanitizer redacts blacklisted passwords, tokens and ke
       testBoolean: false
     };
     const data = loggerSanitizer(testLog);
-    expect(data.testNumber).toEqual('1234');
+    expect(data.testNumber).toEqual(testLog.testNumber);
     expect(data.testUndef).toBeUndefined();
-    expect(data.testNull).toEqual('null');
-    expect(data.testBoolean).toEqual('false');
+    expect(data.testNull).toEqual(testLog.testNull);
+    expect(data.testBoolean).toEqual(testLog.testBoolean);
   });
   it('Should return an Error Object\'s string representation and callstack', () => {
     const data = loggerSanitizer(new Error('I\'m innocuous and possibly helpful'));
-    expect(data).toContain('Error: I\'m innocuous and possibly helpful');
-    expect(data).toContain('logger-sanitizer/index.spec.js:'); // has callstack information
+    expect(data.message).toContain('I\'m innocuous and possibly helpful');
+    expect(data.stack).toContain('logger-sanitizer/index.spec.js:'); // has callstack information
   });
   it('Should return a custom Error Object\'s string representation and callstack', () => {
     class MyCustomError extends Error {
@@ -91,8 +91,8 @@ describe('Logger messages sanitizer redacts blacklisted passwords, tokens and ke
       }
     }
     const data = loggerSanitizer(new MyCustomError('I\'m innocuous and possibly helpful'));
-    expect(data).toContain('Error: I\'m innocuous and possibly helpful');
-    expect(data).toContain('logger-sanitizer/index.spec.js:'); // has callstack information
+    expect(data.message).toContain('I\'m innocuous and possibly helpful');
+    expect(data.stack).toContain('logger-sanitizer/index.spec.js:'); // has callstack information
   });
   it('Should play nicely with other object types', () => {
     const someSet = new Set();
@@ -117,10 +117,10 @@ describe('Logger messages sanitizer redacts blacklisted passwords, tokens and ke
       e: customObjectWithToStringInstance,
     };
     const data = loggerSanitizer(testLog);
-    expect(data.a).toEqual('[object Set]');
-    expect(data.b).toEqual('[object Map]');
-    expect(data.c).toContain('2000-01-01');
-    expect(data.d).toEqual('{"foo":"bar"}');
-    expect(data.e).toEqual(REDACTED);
+    expect(data.a).toEqual(testLog.a);
+    expect(data.b).toEqual(testLog.b);
+    expect(data.c).toEqual(testLog.c)
+    expect(data.d).toEqual(testLog.d);
+    expect(data.e).toEqual({ password: REDACTED });
   });
 });

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "react-redux": "^5.0.7",
     "redis": "^3.0.2",
     "redux": "^3.7.2",
-    "snappy": "^6.3.4"
+    "snappy": "^6.3.4",
+    "traverse": "^0.6.6"
   },
   "devDependencies": {
     "expect": "^24.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2424,6 +2424,11 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+traverse@^0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
+  integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
+
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"


### PR DESCRIPTION
https://imperfectfoods.atlassian.net/browse/EN-62

While working on adapting the website to DataDog, I noticed the sanitizer is adding extra quotes around the fields. I observed this behavior in the loggly console in the past, but hadn't dug into it. Turns out, this is **expected** from inspecting the unit tests! 

In addition, @lukealbao had done work to prevent circular references, but it appears it was only added to https://github.com/imperfectproduce/node-logger/blob/main/src/sanitizer.ts, but the client-side doesn't use the node-logger for sanitization because winston is not an option.  

- [x] Adapt algorithm in node-logger/sanitizer to this function

- [x] Tweak the algorithm to block the value if it contains a blocklist term, not just the key (this differs from Luke's algorithm)

**I don't like that we have two completely separate sanitization functions, one here and one in node-logger, but consolidation can be done at a later time. I just want to get consistent output between client and server log sanitization for the website.**

Notice the extra quotes around the `tags` and `buildId` in the screenshots below that are making it to client-side logs in loggly and DD.

![image](https://user-images.githubusercontent.com/16197461/94999408-30a86c00-0587-11eb-97c2-c6677eab850b.png)
![image](https://user-images.githubusercontent.com/16197461/94999423-4c137700-0587-11eb-9bc9-577fb5ef4660.png)
![image](https://user-images.githubusercontent.com/16197461/94999427-559cdf00-0587-11eb-84c6-1d8789d71ade.png)

